### PR TITLE
Add app config usable in the rag and textsplitter deployments

### DIFF
--- a/app/app_config.yaml
+++ b/app/app_config.yaml
@@ -1,19 +1,19 @@
 ---
 text_splitter:
-  chunk_size: 500
-  chunk_overlap: 0
+  chunk_size: 100
+  chunk_overlap: 50
 embeddings:
-  model_path: ../assets/
+  model_path: "../assets/"
   n_ctx: 2048
-  n_gpu_layers: 24
+  n_gpu_layers: 1
   n_threads: 8
-  n_batch: 1000
+  n_batch: 512
 llm:
-  model_path: ../assets
-  n_gpu_layers: 12
+  model_path: "../assets/llama-2-13b.Q4_0.gguf"
+  n_gpu_layers: 1
   n_batch: 512
   n_ctx: 2048
 rag_prompt:
   template: >
-    [INST]<<SYS>> Something....
+    [INST]<<SYS>> Answer all questions yes or no ONLY no other text at all.
     <</SYS>> \nQuestion: {question} \nContext: {context} \nAnswer: [/INST]

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -6,8 +6,8 @@ http_options:
   port: 8001
 
 applications:
-- name: example-service
-  route_prefix: /example-service
+- name: rag
+  route_prefix: /rag
   import_path: launch:response
   runtime_env: {}
 

--- a/app/launch.py
+++ b/app/launch.py
@@ -4,22 +4,19 @@ from erp.deployments import (
     TextSplitter
 )
 
-from erp.utils import ConfigReader as cr
 
 # Read in the app launch config
-app_config = cr.read_config('./app_config.yaml')
+app_config = "./app_config.yaml"
 
 # deployments with defaults
-text_splitter = TextSplitter.bind()
+text_splitter = TextSplitter.bind(config=app_config)
 embed_and_search = EmbedAndSearch.bind()
 
 # handles dict:
 handles = {
-    'text_splitter': text_splitter,
-    'embed_and_search': embed_and_search
+    "text_splitter": text_splitter,
+    "embed_and_search": embed_and_search
 }
 
-rag = Rag.bind(handles)
-
 # the main show
-response = Rag.bind(handles)
+response = Rag.bind(handles, config=app_config)

--- a/erp/deployments/embed_and_search.py
+++ b/erp/deployments/embed_and_search.py
@@ -1,36 +1,29 @@
-from langchain_community.embeddings import GPT4AllEmbeddings
+import logging
+from langchain_community.embeddings import SentenceTransformerEmbeddings
 from langchain_community.vectorstores import Chroma
 from ray.serve import deployment
+
+logger = logging.getLogger("ray.serve")
 
 
 @deployment
 class EmbedAndSearch:
     """Prepares text to be used in Qa rag chain"""
     def __init__(self):
-        self.embedding = GPT4AllEmbeddings()
+        self.embeddings = SentenceTransformerEmbeddings()
 
     def __call__(self, question, split_text) -> tuple:
         stored_vectors = self.embedder(split_text)
         documents = self.search(question, stored_vectors)
-        formatted_docs = self.document_formatter(documents)
-        return documents, formatted_docs
+        return documents
 
     def embedder(self, split_text):
-        vectorstore = Chroma.from_documents(
-            documents=split_text,
-            embedding=GPT4AllEmbeddings()
+        vectorstore = Chroma.from_texts(
+            split_text,
+            embedding=self.embeddings
         )
         return vectorstore
 
     def search(self, question, vectorstore):
         docs = vectorstore.similarity_search(question)
         return docs
-
-    def document_formatter(self, documents):
-        """Formats docs for langchain QA chain
-        Note:
-            directly from -
-            https://python.langchain.com/docs/use_cases/question_answering/
-                local_retrieval_qa
-        """
-        return "\n\n".join(doc.page_content for doc in documents)

--- a/erp/deployments/rag.py
+++ b/erp/deployments/rag.py
@@ -1,53 +1,107 @@
+import logging
 from starlette.requests import Request
-from langchain import hub
-from langchain_core.output_parsers import StrOutputParser
+# from langchain import hub
+# from langchain_core.output_parsers import StrOutputParser
 # from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnablePassthrough, RunnablePick
-from langchain_community.llms import LlamaCpp
+# from langchain_core.runnables import RunnablePassthrough, RunnablePick
+from langchain.llms import LlamaCpp
 from ray import serve
+from erp.components import Ingress
+from langchain.chains.question_answering import load_qa_chain
+from langchain.prompts.chat import (
+    PromptTemplate,
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate
+)
+from erp.utils import ConfigReader as cr
+
+logger = logging.getLogger("ray.serve")
 
 
 @serve.deployment
-class Rag:
-    def __init__(self, handles: dict):
+class Rag(Ingress):
+    def __init__(
+        self,
+        handles: dict,
+        config: str = None,
+        model_path: str = None,
+        n_gpu_layers: str = 1,
+        n_batch: int = 512,
+        n_ctx: int = 2048,
+    ):
         super().__init__()
-        n_gpu_layers = 1  # Metal set to 1 is enough.
-        n_batch = 512  # Should be between 1 and n_ctx
+        # set all values with config if it exists
+        if config is not None:
+            config_dict = cr.read_config(config)
+            self.model_path = config_dict["llm"]["model_path"]
+            self.n_gpu_layers = config_dict["llm"]["n_gpu_layers"]
+            self.n_batch = config_dict["llm"]["n_batch"]
+            self.n_ctx = config_dict["llm"]["n_ctx"]
+        else:
+            self.model_path = model_path
+            self.n_gpu_layers = n_gpu_layers
+            self.n_batch = n_batch
+            self.n_ctx = n_ctx
 
-        # Make sure the model path is correct for your system!
+        # get the connected deployments
+        self.text_splitter = handles["text_splitter"].options(
+                use_new_handle_api=True
+        )
+        self.embed_and_search = handles["embed_and_search"].options(
+                use_new_handle_api=True
+        )
+
+        # get the model
         self.llm = LlamaCpp(
-            model_path="../assets/llama-2-13b.Q4_0.gguf",
-            n_gpu_layers=n_gpu_layers,
-            n_batch=n_batch,
-            n_ctx=2048,
-            f16_kv=True,  # MUST set to True,
-            verbose=True,
+            model_path=self.model_path,
+            n_gpu_layers=self.n_gpu_layers,
+            n_batch=self.n_batch,
+            n_ctx=self.n_ctx,
+            f16_kv=True,  # must be set to true
+            verbose=False,
         )
         # TODO: replace need to pull
-        self.rag_prompt_llama = hub.pull("rlm/rag-prompt-llama")
-
-        self.text_splitter = handles['text_splitter'].options(
-                use_new_handle_api=True
+        self.rag_prompt = ChatPromptTemplate(
+            input_variables=["question", "context"],
+            messages=[
+                HumanMessagePromptTemplate(
+                    prompt=PromptTemplate(
+                        input_variables=["question", "context"],
+                        template=config_dict["rag_prompt"]["template"]
+                    )
+                )
+            ]
         )
-        self.embed_and_search = handles['embed_and_search'].options(
-                use_new_handle_api=True
+
+        # create the chain
+        self.chain = load_qa_chain(
+            self.llm,
+            chain_type="stuff",
+            prompt=self.rag_prompt
         )
 
     async def __call__(self, request: Request) -> dict:
         request_dict = await self.ingress(request)
-        query = request_dict['query']
-        context = request_dict['context']
+        query = request_dict["query"]
+        context = request_dict["context"]
 
+        # begin rag process
         text_splits = self.text_splitter.remote(context)
-        docs, formatted_docs = self.embed_and_search.remote(query, text_splits)
-
-        # run the chain
-        chain = (
-            RunnablePassthrough.assign(context=RunnablePick("context") | formatted_docs)
-            | self.rag_prompt_llama
-            | self.llm
-            | StrOutputParser()
+        docs = await self.embed_and_search.remote(
+            query,
+            text_splits
         )
+        llm_answer = self.chain(
+            {"input_documents": docs, "question": query}
+        )
+        answer = llm_answer['output_text']
 
-        response = chain.invoke({"context": docs, "question": query})
+        logger.info(f'response type: {type(answer)}')
+        logger.info(f'response: {answer}')
+        response = self.build_response(answer)
+        return response
+
+    def build_response(self, answer: str) -> dict:
+        response = {}
+        response['answer'] = answer
         return response

--- a/erp/deployments/text_splitter.py
+++ b/erp/deployments/text_splitter.py
@@ -1,5 +1,10 @@
+import logging
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from ray.serve import deployment
+from erp.utils import ConfigReader as cr
+
+
+logger = logging.getLogger("ray.serve")
 
 
 @deployment
@@ -7,20 +12,24 @@ class TextSplitter:
     """Prepares text to be embedded"""
     def __init__(
         self,
-        chunk_size: int = 500,
-        chunk_overlap: int = 100
+        config: str = None,
+        chunk_size: int = 25,
+        chunk_overlap: int = 5
     ):
+        if config is not None:
+            config_dict = cr.read_config(config)
+            self.chunk_size = config_dict["text_splitter"]["chunk_size"]
+            self.chunk_overlap = config_dict["text_splitter"]["chunk_overlap"]
+        else:
+            self.chunk_size = chunk_size
+            self.chunk_overlap = chunk_overlap
+
         self.text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size=chunk_size,
-            chunk_overlap=chunk_overlap
+            chunk_size=self.chunk_size,
+            chunk_overlap=self.chunk_overlap
         )
 
     def __call__(self, data: str) -> list:
         """runs the text splitter"""
-
-        text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size=500,
-            chunk_overlap=0
-        )
-        all_splits = text_splitter.split_documents(data)
+        all_splits = self.text_splitter.split_text(data)
         return all_splits


### PR DESCRIPTION
Added the app config to set parameters and prompt without changing source code

* TextSplitter deployment now using config 
* Rag deployment now using config
* Made prompt manually controllable